### PR TITLE
prep v 1.0.12

### DIFF
--- a/code/ado/process_rawbasic.ado
+++ b/code/ado/process_rawbasic.ado
@@ -93,7 +93,7 @@ if `year' >= 2000 & `year' <= 2002 {
 
 * determine dictionary/NBER do-file to use
 * January 2020 - present date
-if  tm(2020m1) <= `datenum' & `datenum' <= tm(2020m10) local nberprogname cpsbjan2020
+if  tm(2020m1) <= `datenum' & `datenum' <= tm(2020m11) local nberprogname cpsbjan2020
 * January 2017 - December 2019
 if  tm(2017m1) <= `datenum' & `datenum' <= tm(2019m12) local nberprogname cpsbjan2017
 * January 2015 - December 2016

--- a/code/variables/generate_basicwgt.do
+++ b/code/variables/generate_basicwgt.do
@@ -10,10 +10,6 @@ if $monthlycps == 1 | $maycps == 1 {
 	}
 	if tm(1998m1) <= $date {
 		replace basicwgt = cmpwgt
-		* use Census 2000-based weights for 2000-2002
-		if tm(2000m1) <= $date & $date <= tm(2002m12) {
-			replace basicwgt = nwcmpwgt
-		}
 	}
 
 	* age restrictions

--- a/documentation/docs/changes/changelog.md
+++ b/documentation/docs/changes/changelog.md
@@ -7,6 +7,16 @@ If you use the EPI extracts for your research, please cite them as
 
 ## Recent changes
 
+### Version 1.0.12 -- 2020-12-10
+
+#### Added
+
+* November 2020 extracts
+
+### Modified
+
+* January-July 2020 basic monthly CPS were re-released by Census to fix a small occupation coding error. These changes to the data have been incorporated in v1.0.12 (https://www.census.gov/programs-surveys/cps/technical-documentation/user-notes/cpsbasic_2020_01.html)
+
 ### Version 1.0.11 -- 2020-11-12
 
 #### Added

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -43,6 +43,6 @@ plugins:
 dev_addr: '127.0.0.1:8282'
 
 extra:
-  version: 1.0.11
-  latestdata: 2020m10
+  version: 1.0.12
+  latestdata: 2020m11
   year: 2020

--- a/master.do
+++ b/master.do
@@ -39,7 +39,7 @@ set trace off
 * DATA VERSION
 *******************************************************************************
 * The version is saved in the dataset labels and notes
-global dataversion 1.0.11
+global dataversion 1.0.12
 
 
 *******************************************************************************
@@ -87,7 +87,7 @@ adopath ++ ${code}ado
 
 * create EPI's extracts from the processed raw data
 * creates both basic monthly and ORG subsample
-create_extracts, begin(1962m1) end(2020m10)
+create_extracts, begin(2000m1) end(2002m12)
 
 * create documentation
 * do ${codedocs}createdocs.do


### PR DESCRIPTION
basicwgt relies on cmpwgt post 1998, which already takes into account the revised weights from 2000-2002 (nwcmpwgt), so there's no need to add the conditional statements replacing basicwgt with nwcmpwgt. 