### PR TITLE
Update generate_mind16.do

### DIFF
--- a/code/variables/generate_mind16.do
+++ b/code/variables/generate_mind16.do
@@ -217,7 +217,6 @@ if $monthlycps == 1 | $maycps == 1 {;
 		);
 		/* Finance, insurance and real estate. Business, auto and repair services, and other professional. */
 		replace mind16 = 9 if	(
-			(indcode == 12) | /* vetrinary services */
 			(indcode == 841) | /* legal services */
 			(indcode >= 700 & indcode <= 712) | /* finance, insurance, and real estate */
 			(indcode >= 721 & indcode <= 760) | /* business and repair services */
@@ -290,7 +289,8 @@ if $monthlycps == 1 | $maycps == 1 {;
 		/* Communications and utilities (treated information as communication) */
 		replace mind16 = 6 if	(
 			(indcode >= 0570 & indcode <= 0690) | /* utilities */
-			(indcode >= 6490 & indcode <= 6780) /* information (excl publishing, incl software publishing */
+			(indcode >= 6490 & indcode <= 6695) | /* information (excl publishing and libraries, incl software publishing) */
+			(indcode >= 6780 & indcode <= 6790)
 		);
 		/* Wholesale trade */
 		replace mind16 = 7 if
@@ -325,8 +325,10 @@ if $monthlycps == 1 | $maycps == 1 {;
 			(indcode >= 8270 & indcode <= 8290)
 		);
 		/* Educational */
-		replace mind16 = 14 if
-			(indcode >= 7860 & indcode <= 7890);
+		replace mind16 = 14 if  (
+			(indcode == 6770) | /* libraries and archives */
+			(indcode >= 7860 & indcode <= 7890)
+		);
 		/* Social services */
 		replace mind16 = 15 if
 			(indcode >= 8370 & indcode <= 8470);


### PR DESCRIPTION
If my understanding is correct, there are three small issues in generate_mind16.do: 1) veterinary services get grouped into both categories 1 and 9 during the IND90 section; and 2) libraries and archives need to be in either Educational or Communications and utilities from IND02 onward. The proposal puts libraries and archives back into Educational. 

The third issue I haven't fully resolved in this PR. The Data processing industry (code 6790) shows up in IND02 and IND07 but is grouped with data hosting and related services starting in IND12 (code 6695). It looks like generate_mind16.do does not capture this industry during IND02 and IND07. My proposed changes allows the industry to be captured and grouped with Communications and utilities in IND02 and IND07. In IND90 and prior, the industry is grouped with Computer services and thus categorized as "Finance, insurance and real estate. Business, auto, repair, and other professional services."

Basically, for the third issue, the Computer and data processing services category could be moved to Communications and utilities in IND80 and IND90, or Data processing and "Data processing, hosting, and related services" could be moved to the "Finance, insurance and real estate. Business, auto, repair, and other professional services." category in the IND02 onward section. The former causes a jump in the FIRE, business, and professional services category; the latter causes a jump in the communications and utilities category. A third option is just to accept the regrouping of categories but capture Data Processing during IND02 and IND07 (which is how this PR handles it). 

Hope this helps in some way. 